### PR TITLE
add new rules from sg repo

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -15,6 +15,7 @@
     "camelcase": "off",
     "no-template-curly-in-string": "off",
     "standard/computed-property-even-spacing": "off",
+    "standard/no-callback-literal": "off",
 
     "linebreak-style": ["error", "unix"],
     "one-var": "off",
@@ -24,6 +25,7 @@
     "no-alert": "error",
     "no-useless-call": "error",
     "radix": "error",
+    "no-useless-escape": "off",
 
     "jest/no-disabled-tests": "error",
     "jest/no-focused-tests": "error",
@@ -39,7 +41,8 @@
     "import/no-duplicates": "error",
     "import/no-extraneous-dependencies": "error",
     "import/no-unresolved": "error",
-    "import/no-webpack-loader-syntax": "error"
+    "import/no-webpack-loader-syntax": "error",
+    "import/first": "off"
   },
 
   "settings": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seatgeek-standard",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "An ESLint configuration for SeatGeek's Javascript code.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Updates a few rules that our main repo was tripping over with the new configuration:

- `standard/no-callback-literal` - some of our callbacks don't follow the standard node practice of `callback(err, ...args)`. Might make sense to fix this at some point, but it's mostly in legacy code

- `no-useless-escape` - this was throwing for some complex regexes. I think prettier will automatically fix these anyway

- `import/first` - it was mostly test files that this broke on, but considering imports are hoisted anyway, we can disable it for now

cc @garetht 